### PR TITLE
Fixed links to source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See [BUILD.md](BUILD.md) documentation
 
 Thank you for installing the [Official Media Bias/Fact Check Extension](https://drmikecrowe.github.io/mbfcext/)!  We appreciate you installing our extension!
 
-Be informed as you read your Facebook feed. We are the most comprehensive media bias resource on the internet. There are currently 1100+ media sources listed in our database and growing every day. Don’t be fooled by Fake News sources. This extension is completely open source, and the source code is hosted [here](https://drmikecrowe.github.io/mbfcext/).
+Be informed as you read your Facebook feed. We are the most comprehensive media bias resource on the internet. There are currently 1100+ media sources listed in our database and growing every day. Don’t be fooled by Fake News sources. This extension is completely open source, and the source code is hosted [here](https://github.com/drmikecrowe/mbfcext).
 
 If you find any issues with this extension, ideas of ways to make it better or simply want to discuss it, we have the [r/MediaBiasFactCheck subreddit](https://www.reddit.com/r/MediaBiasFactCheck/) available.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ comments: true
 
 Thank you for installing the [Official Media Bias/Fact Check Extension](https://drmikecrowe.github.io/mbfcext/)!  We appreciate you installing our extension!
 
-Be informed as you read your Facebook feed. We are the most comprehensive media bias resource on the internet. There are currently 3000+ media sources listed in our database and growing every day. Don’t be fooled by Fake News sources. This extension is completely open source, and the source code is hosted [here](https://drmikecrowe.github.io/mbfcext/).
+Be informed as you read your Facebook feed. We are the most comprehensive media bias resource on the internet. There are currently 3000+ media sources listed in our database and growing every day. Don’t be fooled by Fake News sources. This extension is completely open source, and the source code is hosted [here](https://github.com/drmikecrowe/mbfcext).
 
 If you find any issues with this extension, ideas of ways to make it better or simply want to discuss it, we have the [r/MediaBiasFactCheck subreddit](https://www.reddit.com/r/MediaBiasFactCheck/) available.
 


### PR DESCRIPTION
### Summary
There were a few links that were supposed to link to the source code but instead linked to the documentation website. This PR fixes that issue by changing their URLs from the GitHub Pages website to the GitHub repository.